### PR TITLE
[#31] Swagger 설정 추가 및 코드 아키텍처 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+	// swagger
+	implementation 'com.github.therapi:therapi-runtime-javadoc:0.15.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
+	annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
+
     // db connector
     runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value
+lombok.anyConstructor.addConstructorProperties = true

--- a/src/main/java/com/toy/namoner/common/AppEnvironment.java
+++ b/src/main/java/com/toy/namoner/common/AppEnvironment.java
@@ -1,0 +1,42 @@
+package com.toy.namoner.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Component
+@RequiredArgsConstructor
+public class AppEnvironment {
+	// namoner
+	@Value("${nmn.security.access-secret}")
+	private final String accessTokenSecret;
+	@Value("${nmn.security.access-expiration}")
+	private final long accessTokenExpiration;
+	@Value("${nmn.security.refresh-secret}")
+	private final String refreshTokenSecret;
+	@Value("${nmn.security.refresh-expiration}")
+	private final long refreshTokenExpiration;
+
+	// aws
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	// oauth
+	@Value("${oauth.naver.client.id}")
+	private String clientId;
+	@Value("${oauth.naver.client.secret}")
+	private String clientSecret;
+
+	// aws S3
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+	@Value("${cloud.aws.region.static}")
+	private String s3Region;
+}

--- a/src/main/java/com/toy/namoner/common/config/AwsS3Config.java
+++ b/src/main/java/com/toy/namoner/common/config/AwsS3Config.java
@@ -1,6 +1,5 @@
 package com.toy.namoner.common.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,29 +7,25 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.toy.namoner.common.AppEnvironment;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class AwsS3Config {
 
-    @Value("${cloud.aws.credentials.access-key}") // application.yml 에 명시한 내용
-    private String accessKey;
+	private final AppEnvironment env;
 
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
-    @Value("${cloud.aws.region.static}")
-    private String region;
-
-    @Bean
-    public AmazonS3Client amazonS3Client() {
-        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .build();
-    }
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(env.getAccessKey(), env.getSecretKey());
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withRegion(env.getS3Region())
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
 
 }

--- a/src/main/java/com/toy/namoner/common/config/AwsS3Config.java
+++ b/src/main/java/com/toy/namoner/common/config/AwsS3Config.java
@@ -1,13 +1,15 @@
 package com.toy.namoner.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Slf4j
 @Configuration

--- a/src/main/java/com/toy/namoner/common/config/SwaggerConfig.java
+++ b/src/main/java/com/toy/namoner/common/config/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.toy.namoner.common.config;
+
+import org.springframework.context.annotation.Configuration;
+
+import com.toy.namoner.domain.auth.jwt.JwtUtils;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@Configuration
+@OpenAPIDefinition(
+	info = @io.swagger.v3.oas.annotations.info.Info(
+		title = "Namoner 서버 API",
+		version = SwaggerConfig.API_VERSION
+	),
+	servers = {
+		@Server(url = "http://dev.namoner.site/api", description = "개발 서버"),
+		@Server(url = "/", description = "로컬 서버")
+	}
+)
+@SecurityScheme(
+	name = JwtUtils.AUTHORIZATION_HEADER,
+	type = SecuritySchemeType.HTTP,
+	scheme = "Bearer",
+	bearerFormat = "JWT",
+	in = SecuritySchemeIn.HEADER
+)
+public class SwaggerConfig {
+	public static final String API_VERSION = "v1.0.0";
+}

--- a/src/main/java/com/toy/namoner/common/exceptions/AuthorizationException.java
+++ b/src/main/java/com/toy/namoner/common/exceptions/AuthorizationException.java
@@ -1,7 +1,8 @@
 package com.toy.namoner.common.exceptions;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public class AuthorizationException extends TraceErrorException {

--- a/src/main/java/com/toy/namoner/common/handler/CommonResponseHandler.java
+++ b/src/main/java/com/toy/namoner/common/handler/CommonResponseHandler.java
@@ -15,7 +15,7 @@ public class CommonResponseHandler implements ResponseBodyAdvice<Object> {
 
 	@Override
 	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
-		return true;
+		return returnType.hasMethodAnnotation(NamonerResponse.class);
 	}
 
 	@Override

--- a/src/main/java/com/toy/namoner/common/handler/NamonerResponse.java
+++ b/src/main/java/com/toy/namoner/common/handler/NamonerResponse.java
@@ -1,0 +1,13 @@
+package com.toy.namoner.common.handler;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NamonerResponse {
+}

--- a/src/main/java/com/toy/namoner/common/logs/httpInterface/CachedClientHttpResponse.java
+++ b/src/main/java/com/toy/namoner/common/logs/httpInterface/CachedClientHttpResponse.java
@@ -1,12 +1,12 @@
 package com.toy.namoner.common.logs.httpInterface;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.client.ClientHttpResponse;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 
 public class CachedClientHttpResponse implements ClientHttpResponse {
 

--- a/src/main/java/com/toy/namoner/common/logs/httpInterface/LoggingExchangeFilter.java
+++ b/src/main/java/com/toy/namoner/common/logs/httpInterface/LoggingExchangeFilter.java
@@ -1,16 +1,17 @@
 package com.toy.namoner.common.logs.httpInterface;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.client.ClientHttpRequestExecution;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LoggingExchangeFilter implements ClientHttpRequestInterceptor {

--- a/src/main/java/com/toy/namoner/common/utils/PhoneNumberUtils.java
+++ b/src/main/java/com/toy/namoner/common/utils/PhoneNumberUtils.java
@@ -1,9 +1,9 @@
 package com.toy.namoner.common.utils;
 
-import io.micrometer.common.util.StringUtils;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.micrometer.common.util.StringUtils;
 
 public class PhoneNumberUtils {
     private static final String PHONE_NUMBER_REGEX =

--- a/src/main/java/com/toy/namoner/domain/auth/clients/AuthApiClientsConfig.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/AuthApiClientsConfig.java
@@ -1,11 +1,12 @@
 package com.toy.namoner.domain.auth.clients;
 
-import com.toy.namoner.common.logs.httpInterface.LoggingExchangeFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import com.toy.namoner.common.logs.httpInterface.LoggingExchangeFilter;
 
 @Configuration
 public class AuthApiClientsConfig {

--- a/src/main/java/com/toy/namoner/domain/auth/clients/NaverProfileApiClient.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/NaverProfileApiClient.java
@@ -1,10 +1,11 @@
 package com.toy.namoner.domain.auth.clients;
 
-import com.toy.namoner.domain.auth.clients.dto.response.NaverProfileApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
+
+import com.toy.namoner.domain.auth.clients.dto.response.NaverProfileApiResponse;
 
 @HttpExchange
 public interface NaverProfileApiClient {

--- a/src/main/java/com/toy/namoner/domain/auth/clients/NaverTokenApiClient.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/NaverTokenApiClient.java
@@ -1,10 +1,11 @@
 package com.toy.namoner.domain.auth.clients;
 
-import com.toy.namoner.domain.auth.clients.dto.response.NaverTokenApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
+
+import com.toy.namoner.domain.auth.clients.dto.response.NaverTokenApiResponse;
 
 @HttpExchange
 public interface NaverTokenApiClient {

--- a/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverProfileApiResponse.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverProfileApiResponse.java
@@ -1,10 +1,9 @@
 package com.toy.namoner.domain.auth.clients.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverProfileUserInfoResponse.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverProfileUserInfoResponse.java
@@ -1,7 +1,7 @@
 package com.toy.namoner.domain.auth.clients.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverTokenApiResponse.java
+++ b/src/main/java/com/toy/namoner/domain/auth/clients/dto/response/NaverTokenApiResponse.java
@@ -1,7 +1,5 @@
 package com.toy.namoner.domain.auth.clients.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.toy.namoner.domain.auth.controller;
 
+import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.auth.controller.dto.request.NaverLoginRequest;
 import com.toy.namoner.domain.auth.controller.dto.request.TokenReissueRequest;
 import com.toy.namoner.domain.auth.controller.dto.response.LoginResponse;
@@ -19,14 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final OAuthService naverOAuthService;
-
     private final JwtService jwtService;
+
+    @NamonerResponse
     @PostMapping("/reissue")
     public ResponseEntity<NMNToken> reissueToken(@RequestBody TokenReissueRequest request) {
         NMNToken response = jwtService.reissueToken(request);
 
         return ResponseEntity.ok(response);
     }
+
+    @NamonerResponse
     @PostMapping("/naver")
     public ResponseEntity<Object> naverLogin(@RequestBody NaverLoginRequest request) {
         LoginResponse response = naverOAuthService.getUserInfo(request);

--- a/src/main/java/com/toy/namoner/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/AuthController.java
@@ -1,5 +1,10 @@
 package com.toy.namoner.domain.auth.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.auth.controller.dto.request.NaverLoginRequest;
 import com.toy.namoner.domain.auth.controller.dto.request.TokenReissueRequest;
@@ -7,34 +12,38 @@ import com.toy.namoner.domain.auth.controller.dto.response.LoginResponse;
 import com.toy.namoner.domain.auth.controller.dto.response.NMNToken;
 import com.toy.namoner.domain.auth.jwt.JwtService;
 import com.toy.namoner.domain.auth.service.oauth.OAuthService;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final OAuthService naverOAuthService;
-    private final JwtService jwtService;
+	private final OAuthService naverOAuthService;
+	private final JwtService jwtService;
 
-    @NamonerResponse
-    @PostMapping("/reissue")
-    public ResponseEntity<NMNToken> reissueToken(@RequestBody TokenReissueRequest request) {
-        NMNToken response = jwtService.reissueToken(request);
+	/**
+	 * 토큰 재발급
+	 *
+	 * @param request 토큰 재발급 요청
+	 * @return 재발급된 토큰
+	 */
+	@NamonerResponse
+	@PostMapping("/reissue")
+	public NMNToken reissueToken(@RequestBody TokenReissueRequest request) {
+		return jwtService.reissueToken(request);
+	}
 
-        return ResponseEntity.ok(response);
-    }
-
-    @NamonerResponse
-    @PostMapping("/naver")
-    public ResponseEntity<Object> naverLogin(@RequestBody NaverLoginRequest request) {
-        LoginResponse response = naverOAuthService.getUserInfo(request);
-
-        return ResponseEntity.ok(response);
-    }
+	/**
+	 * 네이버 로그인
+	 *
+	 * @param request 네이버 로그인 요청
+	 * @return 로그인 응답
+	 */
+	@NamonerResponse
+	@PostMapping("/naver")
+	public LoginResponse naverLogin(@RequestBody NaverLoginRequest request) {
+		return naverOAuthService.getUserInfo(request);
+	}
 }

--- a/src/main/java/com/toy/namoner/domain/auth/controller/dto/request/NaverLoginRequest.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/dto/request/NaverLoginRequest.java
@@ -1,7 +1,5 @@
 package com.toy.namoner.domain.auth.controller.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/auth/controller/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/dto/request/TokenReissueRequest.java
@@ -1,6 +1,5 @@
 package com.toy.namoner.domain.auth.controller.dto.request;
 
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/auth/controller/dto/response/LoginResponse.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/dto/response/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.toy.namoner.domain.auth.controller.dto.response;
 
 import com.toy.namoner.domain.user.model.User;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/toy/namoner/domain/auth/controller/dto/response/NMNToken.java
+++ b/src/main/java/com/toy/namoner/domain/auth/controller/dto/response/NMNToken.java
@@ -1,10 +1,10 @@
 package com.toy.namoner.domain.auth.controller.dto.response;
 
+import java.time.LocalDateTime;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/CustomUserDetailService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/CustomUserDetailService.java
@@ -1,13 +1,15 @@
 package com.toy.namoner.domain.auth.jwt;
 
-import com.toy.namoner.common.exceptions.EntityNotFoundException;
-import com.toy.namoner.domain.user.model.User;
-import com.toy.namoner.domain.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import com.toy.namoner.common.exceptions.EntityNotFoundException;
+import com.toy.namoner.domain.user.model.User;
+import com.toy.namoner.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
@@ -26,8 +26,6 @@ public class JwtService {
     private final long ACCESS_EXPIRATION;
     private final long REFRESH_EXPIRATION;
 
-    private final String COOKIE_ACCESS_KEY = "Authorization";
-
     public JwtService(
             CustomUserDetailService customUserDetailService,
             UserService userService,
@@ -70,7 +68,7 @@ public class JwtService {
     }
 
     public String resolveAccessTokenFromHeader(HttpServletRequest request) {
-        String headerValue = request.getHeader(COOKIE_ACCESS_KEY);
+        String headerValue = request.getHeader(JwtUtils.AUTHORIZATION_HEADER);
 
         if (headerValue != null && headerValue.startsWith("Bearer ")) {
             return headerValue.substring(7);

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
@@ -5,12 +5,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import com.toy.namoner.common.AppEnvironment;
 import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.domain.auth.controller.dto.request.TokenReissueRequest;
 import com.toy.namoner.domain.auth.controller.dto.response.NMNToken;
@@ -18,102 +18,93 @@ import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.service.UserService;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class JwtService {
-    private final CustomUserDetailService customUserDetailService;
-    private final UserService userService;
-    private final Key ACCESS_SECRET_KEY;
-    private final Key REFRESH_SECRET_KEY;
-    private final long ACCESS_EXPIRATION;
-    private final long REFRESH_EXPIRATION;
+	private final CustomUserDetailService customUserDetailService;
+	private final UserService userService;
+	private final AppEnvironment env;
 
-    public JwtService(
-            CustomUserDetailService customUserDetailService,
-            UserService userService,
-            @Value("${nmn.security.access-secret}") String accessTokenSecret,
-            @Value("${nmn.security.access-expiration}") long accessTokenExpiration,
-            @Value("${nmn.security.refresh-secret}") String refreshTokenSecret,
-            @Value("${nmn.security.refresh-expiration}") long refreshTokenExpiration
-    ) {
-        this.customUserDetailService = customUserDetailService;
-        this.userService = userService;
-        this.ACCESS_SECRET_KEY = JwtUtils.getSigningKey(accessTokenSecret);
-        this.REFRESH_SECRET_KEY = JwtUtils.getSigningKey(refreshTokenSecret);
-        this.ACCESS_EXPIRATION = accessTokenExpiration;
-        this.REFRESH_EXPIRATION = refreshTokenExpiration;
-    }
+	public NMNToken generateToken(User user) {
+		Date now = new Date();
 
-    public NMNToken generateToken(User user) {
-        Date now = new Date();
+		String accessToken = generateAccessToken(user, now);
+		String refreshToken = generateRefreshToken(user, now);
+		LocalDateTime accessTokenExpiredTime =
+			new Date(now.getTime() + env.getAccessTokenExpiration())
+				.toInstant()
+				.atZone(ZoneId.systemDefault())
+				.toLocalDateTime();
 
-        String accessToken = generateAccessToken(user, now);
-        String refreshToken = generateRefreshToken(user, now);
-        LocalDateTime accessTokenExpiredTime =
-                new Date(now.getTime() + ACCESS_EXPIRATION)
-                .toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDateTime();
+		return NMNToken.create(accessToken, refreshToken, accessTokenExpiredTime);
+	}
 
-        return NMNToken.create(accessToken, refreshToken, accessTokenExpiredTime);
-    }
+	private Key getAccessSecretKey() {
+		return JwtUtils.getSigningKey(env.getAccessTokenSecret());
+	}
 
-    public String generateAccessToken(User user, Date baseTime) {
-        Date expiration = new Date(baseTime.getTime() + ACCESS_EXPIRATION);
-        return JwtUtils.generateAccessToken(ACCESS_SECRET_KEY, expiration, user);
-    }
+	private Key getRefreshSecretKey() {
+		return JwtUtils.getSigningKey(env.getRefreshTokenSecret());
+	}
 
-    public String generateRefreshToken(User user, Date baseTime) {
-        // TODO refreshToken 생성 시 user별 token 저장 로직 필요
-        Date expiration = new Date(baseTime.getTime() + REFRESH_EXPIRATION);
-        return JwtUtils.generateRefreshToken(REFRESH_SECRET_KEY, expiration, user);
-    }
+	public String generateAccessToken(User user, Date baseTime) {
+		Date expiration = new Date(baseTime.getTime() + env.getAccessTokenExpiration());
+		return JwtUtils.generateAccessToken(getAccessSecretKey(), expiration, user);
+	}
 
-    public String resolveAccessTokenFromHeader(HttpServletRequest request) {
-        String headerValue = request.getHeader(JwtUtils.AUTHORIZATION_HEADER);
+	public String generateRefreshToken(User user, Date baseTime) {
+		// TODO refreshToken 생성 시 user별 token 저장 로직 필요
+		Date expiration = new Date(baseTime.getTime() + env.getRefreshTokenExpiration());
+		return JwtUtils.generateRefreshToken(getRefreshSecretKey(), expiration, user);
+	}
 
-        if (headerValue != null && headerValue.startsWith("Bearer ")) {
-            return headerValue.substring(7);
-        }
+	public String resolveAccessTokenFromHeader(HttpServletRequest request) {
+		String headerValue = request.getHeader(JwtUtils.AUTHORIZATION_HEADER);
 
-        return null;
-    }
+		if (headerValue != null && headerValue.startsWith("Bearer ")) {
+			return headerValue.substring(7);
+		}
 
-    public boolean validateAccessToken(String accessToken) {
-        return JwtUtils.isValidToken(accessToken, ACCESS_SECRET_KEY);
-    }
+		return null;
+	}
 
-    public Authentication getAuthentication(String token) {
-        UserDetails principal = customUserDetailService.loadUserByUsername(JwtUtils.getUserId(token, ACCESS_SECRET_KEY));
-        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
-    }
+	public boolean validateAccessToken(String accessToken) {
+		return JwtUtils.isValidToken(accessToken, getAccessSecretKey());
+	}
 
+	public Authentication getAuthentication(String token) {
+		UserDetails principal = customUserDetailService.loadUserByUsername(
+			JwtUtils.getUserId(token, getAccessSecretKey()));
+		return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
+	}
 
-    public boolean validateRefreshToken(String refreshToken) {
-        if (!JwtUtils.isValidToken(refreshToken, REFRESH_SECRET_KEY)) {
-            return false;
-        }
+	public boolean validateRefreshToken(String refreshToken) {
+		if (!JwtUtils.isValidToken(refreshToken, getRefreshSecretKey())) {
+			return false;
+		}
 
-        //TODO 리프레시 토큰 저장해서 값 비교 로직 추가 필요
-        String userId = JwtUtils.getUserId(refreshToken, REFRESH_SECRET_KEY);
+		//TODO 리프레시 토큰 저장해서 값 비교 로직 추가 필요
+		String userId = JwtUtils.getUserId(refreshToken, getRefreshSecretKey());
 
-        return true;
-    }
+		return true;
+	}
 
-    public String getUserIdFromRefreshToken(String refreshToken) {
-        return JwtUtils.getUserId(refreshToken, REFRESH_SECRET_KEY);
-    }
+	public String getUserIdFromRefreshToken(String refreshToken) {
+		return JwtUtils.getUserId(refreshToken, getRefreshSecretKey());
+	}
 
-    public NMNToken reissueToken(TokenReissueRequest request) {
-        String refreshToken = request.getRefreshToken();
+	public NMNToken reissueToken(TokenReissueRequest request) {
+		String refreshToken = request.getRefreshToken();
 
-        if (!validateRefreshToken(refreshToken)) {
-            throw new AuthorizationException("Refresh token is not valid");
-        }
+		if (!validateRefreshToken(refreshToken)) {
+			throw new AuthorizationException("Refresh token is not valid");
+		}
 
-        String userId = getUserIdFromRefreshToken(refreshToken);
-        User user = userService.findByUserId(userId);
+		String userId = getUserIdFromRefreshToken(refreshToken);
+		User user = userService.findByUserId(userId);
 
-        return generateToken(user);
-    }
+		return generateToken(user);
+	}
 }

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/JwtService.java
@@ -1,21 +1,23 @@
 package com.toy.namoner.domain.auth.jwt;
 
-import com.toy.namoner.domain.auth.controller.dto.request.TokenReissueRequest;
-import com.toy.namoner.domain.auth.controller.dto.response.NMNToken;
-import com.toy.namoner.common.exceptions.AuthorizationException;
-import com.toy.namoner.domain.user.model.User;
-import com.toy.namoner.domain.user.service.UserService;
-import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
-import java.security.Key;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
+import com.toy.namoner.common.exceptions.AuthorizationException;
+import com.toy.namoner.domain.auth.controller.dto.request.TokenReissueRequest;
+import com.toy.namoner.domain.auth.controller.dto.response.NMNToken;
+import com.toy.namoner.domain.user.model.User;
+import com.toy.namoner.domain.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @Service
 public class JwtService {

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/JwtUtils.java
@@ -1,7 +1,16 @@
 package com.toy.namoner.domain.auth.jwt;
 
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.domain.user.model.User;
+
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -9,10 +18,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import lombok.extern.slf4j.Slf4j;
-
-import java.nio.charset.StandardCharsets;
-import java.security.Key;
-import java.util.*;
 
 @Slf4j
 public class JwtUtils {

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/JwtUtils.java
@@ -16,6 +16,7 @@ import java.util.*;
 
 @Slf4j
 public class JwtUtils {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     public static String generateAccessToken(final Key ACCESS_KEY, Date expiration, User user) {
         Long now = System.currentTimeMillis();

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/PermittedUrls.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/PermittedUrls.java
@@ -1,9 +1,9 @@
 package com.toy.namoner.domain.auth.jwt;
 
+import java.util.List;
+
 import org.springframework.http.HttpMethod;
 import org.springframework.util.AntPathMatcher;
-
-import java.util.List;
 
 public class PermittedUrls {
 

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/PermittedUrls.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/PermittedUrls.java
@@ -25,7 +25,9 @@ public class PermittedUrls {
         return List.of(
                 "/monitor",
                 "/users/postbox/**",
-                "/users/phone/**"
+                "/users/phone/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
         );
     }
 

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/UserPrincipal.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/UserPrincipal.java
@@ -1,12 +1,13 @@
 package com.toy.namoner.domain.auth.jwt;
 
-import com.toy.namoner.domain.user.model.User;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.Collection;
-import java.util.Collections;
+import com.toy.namoner.domain.user.model.User;
 
 public class UserPrincipal implements UserDetails {
     private User user;

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/filter/ExceptionHandlerFilter.java
@@ -1,13 +1,16 @@
 package com.toy.namoner.domain.auth.jwt.filter;
 
-import com.toy.namoner.common.exceptions.AuthorizationException;
-import jakarta.servlet.*;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
 import org.apache.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
+import com.toy.namoner.common.exceptions.AuthorizationException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/toy/namoner/domain/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/toy/namoner/domain/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,18 +1,20 @@
 package com.toy.namoner.domain.auth.jwt.filter;
 
-import com.toy.namoner.domain.auth.jwt.JwtService;
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.toy.namoner.common.exceptions.AuthorizationException;
+import com.toy.namoner.domain.auth.jwt.JwtService;
 import com.toy.namoner.domain.auth.jwt.PermittedUrls;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/toy/namoner/domain/auth/service/AuthServiceImpl.java
@@ -1,14 +1,15 @@
 package com.toy.namoner.domain.auth.service;
 
+import org.springframework.stereotype.Service;
+
 import com.toy.namoner.domain.auth.controller.dto.response.LoginResponse;
 import com.toy.namoner.domain.auth.controller.dto.response.NMNToken;
 import com.toy.namoner.domain.auth.jwt.JwtService;
 import com.toy.namoner.domain.auth.service.dto.OAuthUserInfo;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.service.UserService;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/service/dto/OAuthUserInfo.java
+++ b/src/main/java/com/toy/namoner/domain/auth/service/dto/OAuthUserInfo.java
@@ -1,7 +1,6 @@
 package com.toy.namoner.domain.auth.service.dto;
 
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/auth/service/oauth/NaverOAuthService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/service/oauth/NaverOAuthService.java
@@ -1,5 +1,10 @@
 package com.toy.namoner.domain.auth.service.oauth;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.domain.auth.clients.NaverProfileApiClient;
 import com.toy.namoner.domain.auth.clients.NaverTokenApiClient;
 import com.toy.namoner.domain.auth.clients.dto.response.NaverProfileApiResponse;
@@ -8,12 +13,9 @@ import com.toy.namoner.domain.auth.controller.dto.request.NaverLoginRequest;
 import com.toy.namoner.domain.auth.controller.dto.response.LoginResponse;
 import com.toy.namoner.domain.auth.service.AuthService;
 import com.toy.namoner.domain.auth.service.dto.OAuthUserInfo;
-import com.toy.namoner.common.exceptions.AuthorizationException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/auth/service/oauth/NaverOAuthService.java
+++ b/src/main/java/com/toy/namoner/domain/auth/service/oauth/NaverOAuthService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.toy.namoner.common.AppEnvironment;
 import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.domain.auth.clients.NaverProfileApiClient;
 import com.toy.namoner.domain.auth.clients.NaverTokenApiClient;
@@ -21,21 +22,18 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class NaverOAuthService implements OAuthService {
-    private final NaverTokenApiClient naverTokenApiClient;
+    private static final String GRANT_TYPE = "authorization_code";
 
+    private final NaverTokenApiClient naverTokenApiClient;
     private final NaverProfileApiClient naverProfileApiClient;
     private final AuthService authService;
-
-    private final String GRANT_TYPE = "authorization_code";
-    @Value("${oauth.naver.client.id}")
-    private String clientId;
-    @Value("${oauth.naver.client.secret}")
-    private String clientSecret;
+    private final AppEnvironment env;
 
     @Override
     public LoginResponse getUserInfo(NaverLoginRequest request) {
 
-        ResponseEntity<NaverTokenApiResponse> tokenResponse = naverTokenApiClient.getToken(GRANT_TYPE, clientId, clientSecret, request.getCode(), request.getState());
+        ResponseEntity<NaverTokenApiResponse> tokenResponse = naverTokenApiClient.getToken(GRANT_TYPE,
+            env.getClientId(), env.getClientSecret(), request.getCode(), request.getState());
         NaverTokenApiResponse token = tokenResponse.getBody();
 
         if (token.isError()) {

--- a/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
@@ -1,5 +1,16 @@
 package com.toy.namoner.domain.letter.controller;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.letter.controller.dto.request.LetterSendRequest;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterListResponse;
@@ -7,39 +18,48 @@ import com.toy.namoner.domain.letter.controller.dto.response.LetterResponse;
 import com.toy.namoner.domain.letter.service.LetterService;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/letters")
 @RequiredArgsConstructor
 public class LetterController {
 
-    private final LetterService letterService;
+	private final LetterService letterService;
 
-    @NamonerResponse
-    @PostMapping
-    public ResponseEntity send(@RequestPart(name = "letterInfo") LetterSendRequest letterSendRequest, @RequestPart(required = false, name = "image") MultipartFile image) {
-        letterService.send(letterSendRequest, image);
-        return ResponseEntity.ok(null);
-    }
+	/**
+	 * 편지 보내기
+	 *
+	 * @param letterSendRequest 편지 정보
+	 * @param image             첨부할 이미지
+	 */
+	@NamonerResponse
+	@PostMapping
+	public void send(@RequestPart(name = "letterInfo") LetterSendRequest letterSendRequest,
+		@RequestPart(required = false, name = "image") MultipartFile image) {
+		letterService.send(letterSendRequest, image);
+	}
 
-    @NamonerResponse
-    @GetMapping
-    public ResponseEntity<List<LetterListResponse>> findLettersByUserId(@RequestParam("userId") String userId) {
-        List<LetterListResponse> letterListResponses = letterService.findLettersByUserId(userId);
+	/**
+	 * 편지함 조회
+	 *
+	 * @param userId 사용자 ID
+	 * @return 편지함 목록
+	 */
+	@NamonerResponse
+	@GetMapping
+	public List<LetterListResponse> findLettersByUserId(@RequestParam("userId") String userId) {
+		return letterService.findLettersByUserId(userId);
+	}
 
-        return ResponseEntity.ok(letterListResponses);
-    }
-
-    @NamonerResponse
-    @GetMapping("/{letterId}")
-    public ResponseEntity<LetterResponse> findByLetterId(@PathVariable("letterId") String letterId) {
-        LetterResponse letterResponse = letterService.getLetterResponseByLetterId(letterId);
-
-        return ResponseEntity.ok(letterResponse);
-    }
+	/**
+	 * 편지 단건 조회
+	 *
+	 * @param letterId 편지 ID
+	 * @return 편지 정보
+	 */
+	@NamonerResponse
+	@GetMapping("/{letterId}")
+	public LetterResponse findByLetterId(@PathVariable("letterId") String letterId) {
+		return letterService.getLetterResponseByLetterId(letterId);
+	}
 }

--- a/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
@@ -1,5 +1,6 @@
 package com.toy.namoner.domain.letter.controller;
 
+import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.letter.controller.dto.request.LetterSendRequest;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterListResponse;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterResponse;
@@ -19,12 +20,14 @@ public class LetterController {
 
     private final LetterService letterService;
 
+    @NamonerResponse
     @PostMapping
     public ResponseEntity send(@RequestPart(name = "letterInfo") LetterSendRequest letterSendRequest, @RequestPart(required = false, name = "image") MultipartFile image) {
         letterService.send(letterSendRequest, image);
         return ResponseEntity.ok(null);
     }
 
+    @NamonerResponse
     @GetMapping
     public ResponseEntity<List<LetterListResponse>> findLettersByUserId(@RequestParam("userId") String userId) {
         List<LetterListResponse> letterListResponses = letterService.findLettersByUserId(userId);
@@ -32,6 +35,7 @@ public class LetterController {
         return ResponseEntity.ok(letterListResponses);
     }
 
+    @NamonerResponse
     @GetMapping("/{letterId}")
     public ResponseEntity<LetterResponse> findByLetterId(@PathVariable("letterId") String letterId) {
         LetterResponse letterResponse = letterService.getLetterResponseByLetterId(letterId);

--- a/src/main/java/com/toy/namoner/domain/letter/controller/dto/request/LetterSendRequest.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/dto/request/LetterSendRequest.java
@@ -1,14 +1,14 @@
 package com.toy.namoner.domain.letter.controller.dto.request;
 
+import java.time.LocalDateTime;
+
 import com.toy.namoner.domain.letter.model.enums.FontType;
 import com.toy.namoner.domain.letter.model.enums.LetterPaperType;
 import com.toy.namoner.domain.letter.model.enums.LetterType;
+
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/letter/controller/dto/response/LetterListResponse.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/dto/response/LetterListResponse.java
@@ -1,14 +1,14 @@
 package com.toy.namoner.domain.letter.controller.dto.response;
 
+import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.toy.namoner.domain.letter.model.Letter;
 import com.toy.namoner.domain.letter.model.enums.LetterType;
+
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/letter/controller/dto/response/LetterResponse.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/dto/response/LetterResponse.java
@@ -3,8 +3,8 @@ package com.toy.namoner.domain.letter.controller.dto.response;
 import com.toy.namoner.domain.letter.model.Letter;
 import com.toy.namoner.domain.letter.model.enums.FontType;
 import com.toy.namoner.domain.letter.model.enums.LetterPaperType;
+
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/letter/model/Letter.java
+++ b/src/main/java/com/toy/namoner/domain/letter/model/Letter.java
@@ -1,15 +1,26 @@
 package com.toy.namoner.domain.letter.model;
 
+import java.time.LocalDateTime;
+
 import com.toy.namoner.domain.letter.controller.dto.request.LetterSendRequest;
 import com.toy.namoner.domain.letter.model.enums.FontType;
 import com.toy.namoner.domain.letter.model.enums.LetterPaperType;
 import com.toy.namoner.domain.letter.model.enums.LetterType;
 import com.toy.namoner.domain.user.model.User;
 
-import jakarta.persistence.*;
-import lombok.*;
-
-import java.time.LocalDateTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder

--- a/src/main/java/com/toy/namoner/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/com/toy/namoner/domain/letter/repository/LetterRepository.java
@@ -1,7 +1,8 @@
 package com.toy.namoner.domain.letter.repository;
 
-import com.toy.namoner.domain.letter.model.Letter;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.toy.namoner.domain.letter.model.Letter;
 
 public interface LetterRepository extends JpaRepository<Letter, String> {
 

--- a/src/main/java/com/toy/namoner/domain/letter/service/LetterService.java
+++ b/src/main/java/com/toy/namoner/domain/letter/service/LetterService.java
@@ -1,12 +1,13 @@
 package com.toy.namoner.domain.letter.service;
 
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import com.toy.namoner.domain.letter.controller.dto.request.LetterSendRequest;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterListResponse;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterResponse;
 import com.toy.namoner.domain.letter.model.Letter;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 public interface LetterService {
     void send(LetterSendRequest letterSendRequest, MultipartFile image);

--- a/src/main/java/com/toy/namoner/domain/user/contoller/UserController.java
+++ b/src/main/java/com/toy/namoner/domain/user/contoller/UserController.java
@@ -1,62 +1,82 @@
 package com.toy.namoner.domain.user.contoller;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.contoller.dto.response.PostBoxResponse;
 import com.toy.namoner.domain.user.contoller.dto.response.UserIdResponse;
 import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.service.UserService;
-import com.toy.namoner.domain.user.contoller.dto.response.PostBoxResponse;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
+	private final UserService userService;
 
-    @NamonerResponse
-    @GetMapping("/postbox/{userId}")
-    public ResponseEntity<PostBoxResponse> getPostBoxResponse(@PathVariable("userId") String userId) {
-        User user = userService.findByUserId(userId);
+	/**
+	 * 사용자의 편지함 정보 조회
+	 *
+	 * @param userId 사용자 아이디
+	 * @return 편지함 정보
+	 */
+	@NamonerResponse
+	@GetMapping("/postbox/{userId}")
+	public PostBoxResponse getPostBoxResponse(@PathVariable("userId") String userId) {
+		User user = userService.findByUserId(userId);
 
-        return ResponseEntity.ok(PostBoxResponse.from(user));
-    }
+		return PostBoxResponse.from(user);
+	}
 
-    @NamonerResponse
-    @GetMapping("/phone/{phoneNumber}")
-    public ResponseEntity<UserIdResponse> getUserIdByPhoneNumber(@PathVariable("phoneNumber") String phoneNumber) {
-        User user = userService.findOrCreateByPhoneNumber(phoneNumber);
+	/**
+	 * 전화번호로 사용자의 아이디 조회
+	 *
+	 * @param phoneNumber 사용자 전화번호
+	 * @return 사용자 아이디
+	 */
+	@NamonerResponse
+	@GetMapping("/phone/{phoneNumber}")
+	public UserIdResponse getUserIdByPhoneNumber(@PathVariable("phoneNumber") String phoneNumber) {
+		User user = userService.findOrCreateByPhoneNumber(phoneNumber);
 
-        return ResponseEntity.ok(UserIdResponse.from(user.getId()));
-    }
+		return UserIdResponse.from(user.getId());
+	}
 
-    @NamonerResponse
-    @PostMapping("/info")
-    public UserInfoUpdateResponse updateUserInfo(@RequestBody UserInfoUpdateRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Object principal = authentication.getPrincipal();
+	/**
+	 * 사용자 정보 수정
+	 *
+	 * @param request 사용자 정보
+	 * @return 업데이트된 사용자 정보
+	 */
+	@NamonerResponse
+	@PostMapping("/info")
+	public UserInfoUpdateResponse updateUserInfo(@RequestBody UserInfoUpdateRequest request) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		Object principal = authentication.getPrincipal();
 
-        String userId = null;
-        if (principal instanceof UserDetails) {
-            userId = ((UserDetails) principal).getUsername();
-        }
+		String userId = null;
+		if (principal instanceof UserDetails) {
+			userId = ((UserDetails)principal).getUsername();
+		}
 
-        if (userId == null) {
-            throw new AuthorizationException("Wrong!");
-        }
+		if (userId == null) {
+			throw new AuthorizationException("Wrong user!");
+		}
 
-
-        UserInfoUpdateResponse response = userService.update(userId, request);
-
-        return response;
-    }
+		return userService.update(userId, request);
+	}
 }

--- a/src/main/java/com/toy/namoner/domain/user/contoller/UserController.java
+++ b/src/main/java/com/toy/namoner/domain/user/contoller/UserController.java
@@ -1,6 +1,7 @@
 package com.toy.namoner.domain.user.contoller;
 
 import com.toy.namoner.common.exceptions.AuthorizationException;
+import com.toy.namoner.common.handler.NamonerResponse;
 import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
 import com.toy.namoner.domain.user.contoller.dto.response.UserIdResponse;
 import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
@@ -22,6 +23,7 @@ public class UserController {
 
     private final UserService userService;
 
+    @NamonerResponse
     @GetMapping("/postbox/{userId}")
     public ResponseEntity<PostBoxResponse> getPostBoxResponse(@PathVariable("userId") String userId) {
         User user = userService.findByUserId(userId);
@@ -29,6 +31,7 @@ public class UserController {
         return ResponseEntity.ok(PostBoxResponse.from(user));
     }
 
+    @NamonerResponse
     @GetMapping("/phone/{phoneNumber}")
     public ResponseEntity<UserIdResponse> getUserIdByPhoneNumber(@PathVariable("phoneNumber") String phoneNumber) {
         User user = userService.findOrCreateByPhoneNumber(phoneNumber);
@@ -36,6 +39,7 @@ public class UserController {
         return ResponseEntity.ok(UserIdResponse.from(user.getId()));
     }
 
+    @NamonerResponse
     @PostMapping("/info")
     public UserInfoUpdateResponse updateUserInfo(@RequestBody UserInfoUpdateRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/toy/namoner/domain/user/contoller/dto/request/UserInfoUpdateRequest.java
+++ b/src/main/java/com/toy/namoner/domain/user/contoller/dto/request/UserInfoUpdateRequest.java
@@ -1,11 +1,8 @@
 package com.toy.namoner.domain.user.contoller.dto.request;
 
-import jakarta.annotation.Nullable;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.misc.NotNull;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/domain/user/contoller/dto/response/PostBoxResponse.java
+++ b/src/main/java/com/toy/namoner/domain/user/contoller/dto/response/PostBoxResponse.java
@@ -3,7 +3,6 @@ package com.toy.namoner.domain.user.contoller.dto.response;
 import com.toy.namoner.domain.user.model.User;
 
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/toy/namoner/domain/user/contoller/dto/response/UserInfoUpdateResponse.java
+++ b/src/main/java/com/toy/namoner/domain/user/contoller/dto/response/UserInfoUpdateResponse.java
@@ -1,6 +1,7 @@
 package com.toy.namoner.domain.user.contoller.dto.response;
 
 import com.toy.namoner.domain.user.model.User;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/toy/namoner/domain/user/controller/UserController.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/UserController.java
@@ -1,4 +1,4 @@
-package com.toy.namoner.domain.user.contoller;
+package com.toy.namoner.domain.user.controller;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.toy.namoner.common.exceptions.AuthorizationException;
 import com.toy.namoner.common.handler.NamonerResponse;
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
-import com.toy.namoner.domain.user.contoller.dto.response.PostBoxResponse;
-import com.toy.namoner.domain.user.contoller.dto.response.UserIdResponse;
-import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
+import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.controller.dto.response.PostBoxResponse;
+import com.toy.namoner.domain.user.controller.dto.response.UserIdResponse;
+import com.toy.namoner.domain.user.controller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.service.UserService;
 

--- a/src/main/java/com/toy/namoner/domain/user/controller/dto/request/UserInfoUpdateRequest.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/dto/request/UserInfoUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.toy.namoner.domain.user.contoller.dto.request;
+package com.toy.namoner.domain.user.controller.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/toy/namoner/domain/user/controller/dto/response/PostBoxResponse.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/dto/response/PostBoxResponse.java
@@ -1,4 +1,4 @@
-package com.toy.namoner.domain.user.contoller.dto.response;
+package com.toy.namoner.domain.user.controller.dto.response;
 
 import com.toy.namoner.domain.user.model.User;
 

--- a/src/main/java/com/toy/namoner/domain/user/controller/dto/response/UserIdResponse.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/dto/response/UserIdResponse.java
@@ -1,4 +1,4 @@
-package com.toy.namoner.domain.user.contoller.dto.response;
+package com.toy.namoner.domain.user.controller.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/toy/namoner/domain/user/controller/dto/response/UserInfoUpdateResponse.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/dto/response/UserInfoUpdateResponse.java
@@ -1,4 +1,4 @@
-package com.toy.namoner.domain.user.contoller.dto.response;
+package com.toy.namoner.domain.user.controller.dto.response;
 
 import com.toy.namoner.domain.user.model.User;
 

--- a/src/main/java/com/toy/namoner/domain/user/model/User.java
+++ b/src/main/java/com/toy/namoner/domain/user/model/User.java
@@ -1,15 +1,25 @@
 package com.toy.namoner.domain.user.model;
 
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
-import com.toy.namoner.domain.user.model.enums.UserStatus;
-import com.toy.namoner.domain.letter.model.Letter;
-import com.toy.namoner.domain.user.model.enums.UserRole;
-
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.toy.namoner.domain.letter.model.Letter;
+import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.model.enums.UserRole;
+import com.toy.namoner.domain.user.model.enums.UserStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity(name = "nmn_user")
 @Builder

--- a/src/main/java/com/toy/namoner/domain/user/model/User.java
+++ b/src/main/java/com/toy/namoner/domain/user/model/User.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.toy.namoner.domain.letter.model.Letter;
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
 import com.toy.namoner.domain.user.model.enums.UserRole;
 import com.toy.namoner.domain.user.model.enums.UserStatus;
 

--- a/src/main/java/com/toy/namoner/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/toy/namoner/domain/user/repository/UserRepository.java
@@ -1,9 +1,10 @@
 package com.toy.namoner.domain.user.repository;
 
-import com.toy.namoner.domain.user.model.User;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import com.toy.namoner.domain.user.model.User;
 
 public interface UserRepository extends JpaRepository<User, String> {
 

--- a/src/main/java/com/toy/namoner/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/namoner/domain/user/service/UserService.java
@@ -2,8 +2,8 @@ package com.toy.namoner.domain.user.service;
 
 import java.util.Optional;
 
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
-import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
+import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.controller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 
 public interface UserService {

--- a/src/main/java/com/toy/namoner/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/namoner/domain/user/service/UserService.java
@@ -1,10 +1,10 @@
 package com.toy.namoner.domain.user.service;
 
+import java.util.Optional;
+
 import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
 import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
-
-import java.util.Optional;
 
 public interface UserService {
     User findOrCreateByPhoneNumber(String phoneNumber);

--- a/src/main/java/com/toy/namoner/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/toy/namoner/domain/user/service/UserServiceImpl.java
@@ -2,12 +2,12 @@ package com.toy.namoner.domain.user.service;
 
 import java.util.Optional;
 
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
-import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
 import org.springframework.stereotype.Service;
 
 import com.toy.namoner.common.error.exceptions.EntityNotFoundException;
 import com.toy.namoner.common.utils.PhoneNumberUtils;
+import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.repository.UserRepository;
 

--- a/src/main/java/com/toy/namoner/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/toy/namoner/domain/user/service/UserServiceImpl.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Service;
 
 import com.toy.namoner.common.error.exceptions.EntityNotFoundException;
 import com.toy.namoner.common.utils.PhoneNumberUtils;
-import com.toy.namoner.domain.user.contoller.dto.request.UserInfoUpdateRequest;
-import com.toy.namoner.domain.user.contoller.dto.response.UserInfoUpdateResponse;
+import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.controller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.repository.UserRepository;
 

--- a/src/main/java/com/toy/namoner/infra/service/ImageService.java
+++ b/src/main/java/com/toy/namoner/infra/service/ImageService.java
@@ -1,8 +1,8 @@
 package com.toy.namoner.infra.service;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageService {
     public static final String LETTER_IMAGE_DIR = "letter";

--- a/src/main/java/com/toy/namoner/infra/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/toy/namoner/infra/service/S3ImageServiceImpl.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,63 +15,62 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.toy.namoner.common.AppEnvironment;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class S3ImageServiceImpl implements ImageService {
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-    @Value("${cloud.aws.region.static}")
-    private String region;
 
-    private final AmazonS3 amazonS3;
+	private final AppEnvironment env;
+	private final AmazonS3 amazonS3;
 
-    @Override
-    public List<String> uploadFiles(String prefix, List<MultipartFile> multipartFiles) {
-        ArrayList<String> fileNameList = new ArrayList<>();
+	@Override
+	public List<String> uploadFiles(String prefix, List<MultipartFile> multipartFiles) {
+		ArrayList<String> fileNameList = new ArrayList<>();
 
-        multipartFiles.forEach(file -> {
-            String fileName = uploadFile(prefix, file);
-            fileNameList.add(fileName);
-        });
+		multipartFiles.forEach(file -> {
+			String fileName = uploadFile(prefix, file);
+			fileNameList.add(fileName);
+		});
 
-        return fileNameList;
-    }
+		return fileNameList;
+	}
 
-    @Override
-    public String uploadFile(String prefix, MultipartFile multipartFile) {
-        String fileName = prefix + "/" + createFileName(multipartFile.getOriginalFilename());
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(multipartFile.getSize());
-        objectMetadata.setContentType(multipartFile.getContentType());
+	@Override
+	public String uploadFile(String prefix, MultipartFile multipartFile) {
+		String fileName = prefix + "/" + createFileName(multipartFile.getOriginalFilename());
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(multipartFile.getSize());
+		objectMetadata.setContentType(multipartFile.getContentType());
 
-        try (InputStream inputStream = multipartFile.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
-                    .withCannedAcl(CannedAccessControlList.PublicRead));
-        } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
-        }
-        return fileName;
-    }
+		try (InputStream inputStream = multipartFile.getInputStream()) {
+			amazonS3.putObject(new PutObjectRequest(env.getBucket(), fileName, inputStream, objectMetadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+		} catch (IOException e) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+		}
+		return fileName;
+	}
 
-    @Override
-    public String getFileUrl(String fileName) {
-        if (fileName == null || fileName.isEmpty()) {
-            return null;
-        }
-        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
-    }
-    private String createFileName(String fileName) {
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-    }
+	@Override
+	public String getFileUrl(String fileName) {
+		if (fileName == null || fileName.isEmpty()) {
+			return null;
+		}
+		return "https://%s.s3.%s.amazonaws.com/%s".formatted(env.getBucket(), env.getRegion(), fileName);
+	}
 
-    private String getFileExtension(String fileName) {
-        try {
-            return fileName.substring(fileName.lastIndexOf("."));
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일" + fileName + ") 입니다.");
-        }
-    }
+	private String createFileName(String fileName) {
+		return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+	}
+
+	private String getFileExtension(String fileName) {
+		try {
+			return fileName.substring(fileName.lastIndexOf("."));
+		} catch (StringIndexOutOfBoundsException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일" + fileName + ") 입니다.");
+		}
+	}
 }

--- a/src/main/java/com/toy/namoner/infra/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/toy/namoner/infra/service/S3ImageServiceImpl.java
@@ -1,21 +1,23 @@
 package com.toy.namoner.infra.service;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/toy/namoner/monitor/MonitorController.java
+++ b/src/main/java/com/toy/namoner/monitor/MonitorController.java
@@ -6,6 +6,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class MonitorController {
 
+	/**
+	 * 모니터링용 엔드포인트
+	 */
 	@GetMapping("/monitor")
 	public void monitor() {
 	}


### PR DESCRIPTION
organize imports, 패키지명 변경이 있어서 커밋별로 보시면 편할거에요!

### 변경사항
- Swagger 추가
- `@NamonerResponse` 어노테이션 추가
  - 컨트롤러 메서드에 @NamonerResponse를 붙여야만 Response<T>로 응답 자동 wrapping하도록 변경
    - `/v3/api-docs`와 같이 swagger내부에서 사용하는 응답도 Response로 wrapping하더라구요..
    - swagger뿐만 아니라 다른 라이브러리에서도 예기치 못한 동작을 피하기 위해 수동으로 `@NamonerResponse`를 붙이도록 했습니다.
- 기존 컨트롤러에 NamonerResponse 및 swagger 문서 추가
- swagger 문서는 주석으로 달 수 있습니다. Controller 참고해주세요~