### PR TITLE
feat: [#46] 편지 list 조회 시 권한 확인 추가

### DIFF
--- a/src/main/java/com/toy/namoner/common/jwt/NMNAuthentication.java
+++ b/src/main/java/com/toy/namoner/common/jwt/NMNAuthentication.java
@@ -1,6 +1,7 @@
 package com.toy.namoner.common.jwt;
 
 import com.toy.namoner.domain.auth.role.UserRole;
+import com.toy.namoner.domain.user.model.User;
 import org.springframework.security.core.Authentication;
 
 public interface NMNAuthentication extends Authentication {
@@ -8,5 +9,6 @@ public interface NMNAuthentication extends Authentication {
 
     UserRole getUserRole();
 
+    boolean verifyUser(User user);
     boolean isGuest();
 }

--- a/src/main/java/com/toy/namoner/common/jwt/NMNAuthenticationImpl.java
+++ b/src/main/java/com/toy/namoner/common/jwt/NMNAuthenticationImpl.java
@@ -79,4 +79,8 @@ public class NMNAuthenticationImpl implements NMNAuthentication {
     public String getName() {
         return null;
     }
+    @Override
+    public boolean verifyUser(User user) {
+        return userId.equals(user.getId());
+    }
 }

--- a/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
+++ b/src/main/java/com/toy/namoner/domain/letter/controller/LetterController.java
@@ -1,6 +1,5 @@
 package com.toy.namoner.domain.letter.controller;
 
-import java.security.Principal;
 import java.util.List;
 
 import com.toy.namoner.common.jwt.NMNAuthentication;
@@ -53,8 +52,9 @@ public class LetterController {
 	 */
 	@NamonerResponse
 	@GetMapping
-	public List<LetterListResponse> findLettersByUserId(@RequestParam("userId") String userId) {
-		return letterService.findLettersByUserId(userId);
+	@UserAuth
+	public List<LetterListResponse> findLettersByUserId(NMNAuthentication authentication, @RequestParam("userId") String userId) {
+		return letterService.findLettersByUserId(authentication, userId);
 	}
 
 	/**

--- a/src/main/java/com/toy/namoner/domain/letter/service/LetterService.java
+++ b/src/main/java/com/toy/namoner/domain/letter/service/LetterService.java
@@ -59,8 +59,12 @@ public class LetterService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<LetterListResponse> findLettersByUserId(String userId) {
+	public List<LetterListResponse> findLettersByUserId(NMNAuthentication authentication, String userId) {
 		User user = userService.findByUserId(userId);
+
+		if (!authentication.verifyUser(user)) {
+			throw new AuthorizationException("User " + userId + " is not authorized");
+		}
 
 		List<Letter> sortedLetters = sortLetter(user.getReceiveLetters());
 

--- a/src/test/java/com/toy/namoner/letter/service/LetterServiceTest.java
+++ b/src/test/java/com/toy/namoner/letter/service/LetterServiceTest.java
@@ -1,5 +1,7 @@
 package com.toy.namoner.letter.service;
 
+import com.toy.namoner.common.jwt.NMNAuthentication;
+import com.toy.namoner.common.jwt.NMNAuthenticationImpl;
 import com.toy.namoner.domain.letter.controller.dto.response.LetterListResponse;
 import com.toy.namoner.domain.letter.model.Letter;
 import com.toy.namoner.domain.letter.model.enums.LetterType;
@@ -64,8 +66,10 @@ class LetterServiceTest {
 
         when(userService.findByUserId(userId)).thenReturn(mockUser);
 
+        NMNAuthentication authentication = NMNAuthenticationImpl.create(mockUser);
+
         // When
-        List<LetterListResponse> result = letterService.findLettersByUserId(userId);
+        List<LetterListResponse> result = letterService.findLettersByUserId(authentication, userId);
 
         // Then
         assertThat(result).hasSize(6);


### PR DESCRIPTION
- api는 유저만 호출 가능
- 자신의 편지 list가 아닌 경우 권한 불가 처리