### PR TITLE
[#65] 회원 탈퇴 구현 및 오류 기능 개선

### DIFF
--- a/src/main/java/com/toy/namoner/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/toy/namoner/common/error/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Throwable.class)
-	public ResponseEntity<Response<Void>> exceptionHandler(Throwable throwable, HttpServletRequest request) {
+	public ResponseEntity<Response<Void>> handleThrowable(Throwable throwable, HttpServletRequest request) {
 		TraceErrorException exception;
 
 		if (throwable instanceof TraceErrorException) {

--- a/src/main/java/com/toy/namoner/common/jwt/SecurityConfig.java
+++ b/src/main/java/com/toy/namoner/common/jwt/SecurityConfig.java
@@ -15,6 +15,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.namoner.common.error.GlobalExceptionHandler;
 import com.toy.namoner.common.jwt.filter.ExceptionHandlerFilter;
 import com.toy.namoner.common.jwt.filter.JwtAuthenticationFilter;
 import com.toy.namoner.domain.auth.role.UserRole;
@@ -26,8 +28,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
-    private static final String PERMITTED_ROLES[] = {UserRole.ADMIN.getValue(), UserRole.USER.getValue()};
-    private final JwtService jwtService;
+	private final JwtAuthenticationFilter authenticationFilter;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -39,9 +41,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .cors(cors -> cors.configurationSource(customCorsConfigurationSource()))
                 // JWT 검증 필터 추가
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService),
-                        UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class);
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/toy/namoner/common/jwt/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/toy/namoner/common/jwt/filter/ExceptionHandlerFilter.java
@@ -2,24 +2,40 @@ package com.toy.namoner.common.jwt.filter;
 
 import java.io.IOException;
 
-import org.apache.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.toy.namoner.common.error.exceptions.AuthorizationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.namoner.common.error.GlobalExceptionHandler;
+import com.toy.namoner.common.model.Response;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
+@Component
+@RequiredArgsConstructor
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try {
-            filterChain.doFilter(request, response);
-        } catch (AuthorizationException e) {
-            response.setStatus(HttpStatus.SC_UNAUTHORIZED);
-        }
-    }
+	private final GlobalExceptionHandler exceptionHandler;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (Throwable t) {
+			ResponseEntity<Response<Void>> entity = exceptionHandler.handleThrowable(t, request);
+			String bodyJson = objectMapper.writeValueAsString(entity.getBody());
+
+			response.setStatus(entity.getStatusCode().value());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.getWriter().write(bodyJson);
+			response.flushBuffer();
+		}
+	}
 }

--- a/src/main/java/com/toy/namoner/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/toy/namoner/common/jwt/filter/JwtAuthenticationFilter.java
@@ -9,11 +9,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/toy/namoner/domain/user/controller/UserController.java
+++ b/src/main/java/com/toy/namoner/domain/user/controller/UserController.java
@@ -1,10 +1,6 @@
 package com.toy.namoner.domain.user.controller;
 
-import com.toy.namoner.common.jwt.NMNAuthentication;
-import com.toy.namoner.domain.auth.role.UserAuth;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,8 +8,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.toy.namoner.common.error.exceptions.AuthorizationException;
 import com.toy.namoner.common.handler.NamonerResponse;
+import com.toy.namoner.common.jwt.NMNAuthentication;
+import com.toy.namoner.domain.auth.role.UserAuth;
 import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
 import com.toy.namoner.domain.user.controller.dto.response.PostBoxResponse;
 import com.toy.namoner.domain.user.controller.dto.response.UserIdResponse;
@@ -64,5 +61,17 @@ public class UserController {
 	@PostMapping("/info")
 	public UserInfoUpdateResponse updateUserInfo(NMNAuthentication authentication, @RequestBody UserInfoUpdateRequest request) {
 		return userService.update(authentication, request);
+	}
+
+	/**
+	 * 사용자 회원 탈퇴
+	 *
+	 * @return 사용자 아이디
+	 */
+	@NamonerResponse
+	@UserAuth
+	@DeleteMapping
+	public UserIdResponse withdrawUser(NMNAuthentication authentication) {
+		return userService.withdraw(authentication);
 	}
 }

--- a/src/main/java/com/toy/namoner/domain/user/model/User.java
+++ b/src/main/java/com/toy/namoner/domain/user/model/User.java
@@ -1,13 +1,13 @@
 package com.toy.namoner.domain.user.model;
 
-import com.toy.namoner.common.model.BaseEntity;
-import com.toy.namoner.domain.user.model.enums.UserStatus;
-import com.toy.namoner.domain.letter.model.Letter;
-import com.toy.namoner.domain.auth.role.UserRole;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.toy.namoner.common.model.BaseEntity;
+import com.toy.namoner.domain.auth.role.UserRole;
+import com.toy.namoner.domain.letter.model.Letter;
 import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.model.enums.UserStatus;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -79,5 +79,13 @@ public class User extends BaseEntity {
         postboxName = updateInfo.getPostBoxName();
         isPhoneConnected = updateInfo.getIsPhoneConnected();
         status = UserStatus.SIGNED;
+    }
+
+    public boolean isEnabled() {
+        return UserStatus.DISABLED != status;
+    }
+
+    public void setToDisable() {
+        this.status = UserStatus.DISABLED;
     }
 }

--- a/src/main/java/com/toy/namoner/domain/user/model/enums/UserStatus.java
+++ b/src/main/java/com/toy/namoner/domain/user/model/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.toy.namoner.domain.user.model.enums;
 
 public enum UserStatus {
-    NOT_SIGNED, SIGNED
+    NOT_SIGNED, SIGNED, DISABLED
 }

--- a/src/main/java/com/toy/namoner/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/namoner/domain/user/service/UserService.java
@@ -2,17 +2,17 @@ package com.toy.namoner.domain.user.service;
 
 import java.util.Optional;
 
-import com.toy.namoner.common.error.exceptions.UserNotAllowedException;
-import com.toy.namoner.common.jwt.NMNAuthentication;
-import com.toy.namoner.domain.user.controller.dto.response.PostBoxResponse;
-import com.toy.namoner.domain.user.controller.dto.response.UserIdResponse;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.toy.namoner.common.error.exceptions.EntityNotFoundException;
+import com.toy.namoner.common.error.exceptions.UserNotAllowedException;
+import com.toy.namoner.common.jwt.NMNAuthentication;
 import com.toy.namoner.common.utils.PhoneNumberUtils;
 import com.toy.namoner.domain.user.controller.dto.request.UserInfoUpdateRequest;
+import com.toy.namoner.domain.user.controller.dto.response.PostBoxResponse;
+import com.toy.namoner.domain.user.controller.dto.response.UserIdResponse;
 import com.toy.namoner.domain.user.controller.dto.response.UserInfoUpdateResponse;
 import com.toy.namoner.domain.user.model.User;
 import com.toy.namoner.domain.user.repository.UserRepository;
@@ -54,6 +54,7 @@ public class UserService {
 		}
 
 		return userRepository.findById(userId)
+			.filter(User::isEnabled)
 			.orElseThrow(() -> new EntityNotFoundException("User " + userId + " not found"));
 	}
 
@@ -87,6 +88,14 @@ public class UserService {
 		if (!user.getIsPhoneConnected()) {
 			throw new UserNotAllowedException("User " + phoneNumber + " is not allowed to access");
 		}
+		return UserIdResponse.from(user);
+	}
+
+	@Transactional
+	public UserIdResponse withdraw(NMNAuthentication authentication) {
+		User user = findByUserId(authentication.getUserId());
+		user.setToDisable();
+
 		return UserIdResponse.from(user);
 	}
 }


### PR DESCRIPTION
- 오류 handling하던 부분 코드 개선했습니다.
  - filter에서 발생하는 오류도 GlobalExceptionHandler에서 처리하도록 했습니다.
  - 그래야 모든 오류가 동일한 형태가 되고, 오류 코드가 정확하게 표시됩니다.
    - 이전에는 filter에서 발생하는 오류와 컨트롤러에서 발생하는 오류의 응답 형태가 달랐습니다.
    - EntityNotFound는 404오류인데 500오류가 나고 있었습니다.
    - 이런 안맞는 부분들을 모두 공통화하여 통일했습니다.
- 회원 탈퇴 기능을 만들었습니다.
  - 탈퇴된 회원은 `status`가 `DISABLED`가 되며, 조회시에도 `DISABLED`인 회원은 제외됩니다.